### PR TITLE
Add support for LoadBalancer metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Local environment
+.envrc
+
+# Bin directory
+bin/
+
+# Dependency directories (remove the comment below to include it)
+vendor/
+
+# editors
+*.swp
+

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Note: `ZONE_<name>` configuration is not supported as flag.
 # HELP cloudflare_zone_threats_country Threats per zone per country
 # HELP cloudflare_zone_threats_total Threats per zone
 # HELP cloudflare_zone_uniques_total Uniques per zone
+# HELP cloudflare_zone_pool_health_status Reports the health of a pool, 1 for healthy, 0 for unhealthy.
 ```
 
 ## Helm chart repository

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Note: `ZONE_<name>` configuration is not supported as flag.
 # HELP cloudflare_zone_requests_ssl_encrypted Number of encrypted requests for zone
 # HELP cloudflare_zone_requests_status Number of request for zone per HTTP status
 # HELP cloudflare_zone_requests_status_country_host Count of requests for zone per edge HTTP status per country per host
+# HELP cloudflare_zone_requests_browser_map_page_views_count Number of successful requests for HTML pages per zone
 # HELP cloudflare_zone_requests_total Number of requests for zone
 # HELP cloudflare_zone_threats_country Threats per zone per country
 # HELP cloudflare_zone_threats_total Threats per zone

--- a/main.go
+++ b/main.go
@@ -84,6 +84,7 @@ func fetchMetrics() {
 
 		go fetchZoneAnalytics(targetZones, &wg)
 		go fetchZoneColocationAnalytics(targetZones, &wg)
+		go fetchLoadBalancerAnalytics(targetZones, &wg)
 	}
 
 	wg.Wait()

--- a/prometheus.go
+++ b/prometheus.go
@@ -48,6 +48,12 @@ var (
 	}, []string{"zone", "status"},
 	)
 
+	zoneRequestBrowserMap = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "cloudflare_zone_requests_browser_map_page_views_count",
+		Help: "Number of successful requests for HTML pages per zone",
+	}, []string{"zone", "family"},
+	)
+
 	zoneRequestOriginStatusCountryHost = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "cloudflare_zone_requests_origin_status_country_host",
 		Help: "Count of not cached requests for zone per origin HTTP status per country per host",
@@ -280,6 +286,10 @@ func addHTTPGroups(z *zoneResp, name string) {
 
 	for _, status := range zt.Sum.ResponseStatus {
 		zoneRequestHTTPStatus.With(prometheus.Labels{"zone": name, "status": strconv.Itoa(status.EdgeResponseStatus)}).Add(float64(status.Requests))
+	}
+
+	for _, browser := range zt.Sum.BrowserMap {
+		zoneRequestBrowserMap.With(prometheus.Labels{"zone": name, "family": browser.UaBrowserFamily}).Add(float64(browser.PageViews))
 	}
 
 	zoneBandwidthTotal.With(prometheus.Labels{"zone": name}).Add(float64(zt.Sum.Bytes))


### PR DESCRIPTION
## Description
This PR enables support for CloudFlare LoadBalancer metrics.

Introduces the following changes:
*       feat: Export LoadBalancer analytics metrics

    This commit enables support for exporting LoadBalancer analytics
    metrics. LoadBalancer's pool health is reported:
    * 1 -> health
    * 0 -> unhealthy
    
  as long as the number of requests each pool receives from each CFL
      network location[1]

 1. https://developers.cloudflare.com/load-balancing/reference/load-balancing-analytics/#graphql-analytics
*     feat: Export browser map page views count

    Export browser_map_page_views_count requests metric

## Test plan
All changes have been tested locally with a local monitoring stack pulling metrics.
* LoadBalancers pool health:
![Screenshot 2022-04-11 at 2 32 00 PM](https://user-images.githubusercontent.com/24883189/162730984-cc0ded55-637f-4c6d-b684-3a618b4404b4.png)

* Browser map page views per family
![Screenshot 2022-04-11 at 2 37 49 PM](https://user-images.githubusercontent.com/24883189/162731789-e3ac5674-279d-4498-b5fe-9ace8e27c788.png)

